### PR TITLE
Fix mobile styles for iPhone 5/SE

### DIFF
--- a/src/js/modules/core/components/AboutPage.tsx
+++ b/src/js/modules/core/components/AboutPage.tsx
@@ -13,7 +13,7 @@ const styles = (theme: Theme): Styles => ({
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    width: "80vw",
+    width: "100%",
     padding: "5%"
   },
   icons: {
@@ -22,6 +22,7 @@ const styles = (theme: Theme): Styles => ({
     justifyContent: "space-around"
   },
   text: {
+    padding: "0 10px 0",
     maxWidth: "500px"
   }
 });
@@ -47,9 +48,9 @@ const AboutPage: React.SFC<Props> = ({ classes }) => {
         <FontAwesomeIcon icon={faAws} />
       </div>
       <p className={classes.text}>
-        This site is written in React with TypeScript, Firebase, JSS and Redux.
-        It is hosted on AWS. If you have any complaints/bugs/compliments, please
-        email nick at nicholasyang.com.
+      This site is written in React with TypeScript, Firebase, JSS and Redux.
+      It is hosted on AWS. It is hosted on AWS.
+      If you have any complaints, bugs or compliments, please email nick at nicholasyang.com.
       </p>
     </div>
   );

--- a/src/js/modules/core/components/HomePage.tsx
+++ b/src/js/modules/core/components/HomePage.tsx
@@ -43,7 +43,8 @@ const styles = (theme: Theme): HomePageStyles<JssRules> => ({
     display: "flex",
     flexDirection: "column",
     backgroundColor: theme.backgroundColor,
-    alignItems: "center"
+    alignItems: "center",
+    width: "100%"
   },
   aboutSection: {
     backgroundColor: theme.secondBackground,
@@ -77,7 +78,8 @@ const styles = (theme: Theme): HomePageStyles<JssRules> => ({
     display: "flex",
     flexDirection: "column",
     // Small hack for Chrome. Not sure why.
-    backgroundColor: theme.thirdBackground
+    backgroundColor: theme.thirdBackground,
+    width: "100%"
   },
   timeline: {
     width: "20vw"

--- a/src/js/modules/core/components/MainApp.tsx
+++ b/src/js/modules/core/components/MainApp.tsx
@@ -18,7 +18,7 @@ const styles = (theme: Theme): Styles => ({
     color: theme.fontColor,
     transition: "background-color 2s, font-color 2s",
     fontFamily: theme.fontFamily,
-    width: "100vw",
+    width: "100%",
     display: "flex",
     flexDirection: "column",
     alignItems: "center",


### PR DESCRIPTION
Fix the styles in the MainApp.tsx. Replace unit vw to %. Now, the left side of the links are not covered by left boundary. Test it on all IPhone series, all nexus series and all galaxy series. Looks fine. Let me know anything problematic. 